### PR TITLE
Compatibility updates and install scripts

### DIFF
--- a/P4_examples/P4-XDP_example/README.md
+++ b/P4_examples/P4-XDP_example/README.md
@@ -1,16 +1,21 @@
 # P4-XDP on P4-Containernet
 
 ## Installation
+### Manual installation
 Follow instruction from [here](https://github.com/vmware/p4c-xdp) to install the P4_16-XDP compiler.
-
 Then set the environment variable `$P4C` to the path of the P4 compiler folder (usually `~/p4c/`).
+
+### Automatic installation
+Alternatively, you can install the compiler by executing the script `FOP4/util/install-p4c-xdp.sh`.
+The script will add necessary environment variables to your bash profile file.
+To load them without rebooting, run `source ~/.profile`
 
 ## Compile P4 program for eBPF-XDP target (p4c-xdp)
 You can compile the P4 program to the eBPF-XDP target running the following commands. First copy the `ebpf_xdp.h`
 ```bash
 cp ${P4C}/extensions/p4c-xdp/tests/ebpf_xdp.h .
 p4c-xdp --target xdp -o PROGRAM_NAME.c PROGRAM_NAME.p4
-clang -I ${P4C}/extensions/p4c-xdp/p4include -I${P4C}/backends/ebpf/runtime/ \
+clang -I ${P4C}/extensions/p4c-xdp/p4include -I${P4C}/backends/ebpf/runtime/ -I${P4C}/backends/ebpf/runtime/usr/include/bpf \
     -Wno-unused-value -Wno-pointer-sign \
     -Wno-compare-distinct-pointer-types \
     -Wno-gnu-variable-sized-type-not-at-end \

--- a/P4_examples/P4-XDP_example/p4src/Makefile
+++ b/P4_examples/P4-XDP_example/p4src/Makefile
@@ -2,7 +2,7 @@ all: program
 
 program: program.p4
 	p4c-xdp --target xdp -o program.c program.p4
-	clang -I ${P4C}/extensions/p4c-xdp/p4include -I${P4C}/backends/ebpf/runtime/ \
+	clang -I ${P4C}/extensions/p4c-xdp/p4include -I${P4C}/backends/ebpf/runtime/ -I${P4C}/backends/ebpf/runtime/usr/include/bpf \
 		-Wno-unused-value -Wno-pointer-sign \
 		-Wno-compare-distinct-pointer-types \
 		-Wno-gnu-variable-sized-type-not-at-end \

--- a/P4_examples/README.md
+++ b/P4_examples/README.md
@@ -35,14 +35,29 @@ See [here](https://github.com/jafingerhut/p4-guide/blob/master/bin/README-instal
 
 ## Instructions
 
+### Prerequisites
+
+To be able to run the following examples, the needed Docker containers have to be already built.
+To build them, run `FOP4/examples/example-containers/build.sh`
+
+### Running
+
 First you need to compile the P4 pipeline using the `make` command on the folders `load_balancer_hash` and `load_balancer_RR`.
 
 Then you can run the script `load_balancer_hash_p4.py` or the script `load_balancer_RR_p4.py` to run the previously described topology.
 
 Finally, you need to populate the tables of the switch using the command `simple_switch_CLI --thrift-port $(cat /tmp/bmv2-s1-thrift-port) < command.txt`.
 
+```bash
+containernet> sh simple_switch_CLI --thrift-port $(cat /tmp/bmv2-s1-thrift-port) < command.txt
+```
+
 If you try to contact the LAMP webserver at the address 192.168.1.100 you will be served alternatively from the host with IP 192.168.1.200 or the host with IP 192.168.1.201.
 To check it you can try to open the page `index.php` and you can check the address of the server that served the page (search for **SERVER_ADDR** field).
+
+```bash
+containernet> h1 curl -s 192.168.1.100/index.php | grep SERVER_ADDR
+```
 
 ## Miniedit.py
 

--- a/P4_examples/eINT/README.md
+++ b/P4_examples/eINT/README.md
@@ -5,23 +5,24 @@
 ![Scenario3](https://github.com/ANTLab-polimi/FOP4/raw/master/P4_examples/eINT/doc/UC3_2.png)
 
 ## Example of functionality
-![Scenario3Example](https://github.com/ANTLab-polimi/FOP4/raw/master/P4_examples/eINT//doc/UC3_1.png)
+![Scenario3Example](https://github.com/ANTLab-polimi/FOP4/raw/master/P4_examples/eINT/doc/UC3_1.png)
 
 
-## Demo walkthorough
+## Demo walkthrough
 
 ### Step 1: Add int-vnf
 
 ```sh
 cd int-vnf/
-./buid.sh
+./build.sh
+cd ..
 ```
 
 ### Step 2: Start FOP4 topology
 
 
 ```sh
-sudo python eint_topology.py
+sudo python3 eint_topology.py
 
 # check if things run in FOP4:
 containernet> dump
@@ -36,7 +37,7 @@ containernet> dump
 <ONOSBmv2Switch s4: lo:127.0.0.1,s4-eth1:None,s4-eth2:None,s4-eth3:None pid=14403> 
 
 # check Docker status
-$ docker ps
+containernet> sh docker ps
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
 2f3585b0c837        fop4_example:eINT   "/bin/bash"         53 seconds ago      Up 52 seconds                           mn.v2
 ac083b30a046        fop4_example:eINT   "/bin/bash"         54 seconds ago      Up 54 seconds                           mn.v1

--- a/P4_examples/load_balancer_RR/load_balancer_RR.p4
+++ b/P4_examples/load_balancer_RR/load_balancer_RR.p4
@@ -199,7 +199,7 @@ control LoadBalancer(inout headers_t hdr,
     }
 
     action _drop() {
-        mark_to_drop();
+        mark_to_drop(standard_metadata);
     }
 
     action set_nhop(bit<48> nhop_dmac, bit<32> nhop_ipv4, port_t port){
@@ -314,7 +314,7 @@ control c_ingress(inout headers_t hdr,
     }
 
     action _drop() {
-        mark_to_drop();
+        mark_to_drop(standard_metadata);
     }
 
     // Table counter used to count packets and bytes matched by each entry of

--- a/P4_examples/load_balancer_RR/load_balancer_RR_p4.py
+++ b/P4_examples/load_balancer_RR/load_balancer_RR_p4.py
@@ -23,6 +23,7 @@ info('*** Adding docker containers\n')
 # Fake HOST
 d1 = net.addDocker('d1', cls=P4DockerHost, ip='192.168.1.100',
                    dimage="containernet_example:ubuntup4", mac="00:00:00:00:00:01")
+d1.start()
 # HOST
 h1 = net.addHost('h1', ip='192.168.1.104', mac="00:00:00:00:00:04")
 h2 = net.addHost('h2', ip='192.168.1.105', mac="00:00:00:00:00:05")
@@ -36,8 +37,10 @@ h2 = net.addHost('h2', ip='192.168.1.105', mac="00:00:00:00:00:05")
 # LAMP servers
 d2 = net.addDocker('d2', cls=P4DockerHost, ip='192.168.1.200',
                    dimage="containernet_example:lamp", mac="00:00:00:00:00:A0")
+d2.start()
 d3 = net.addDocker('d3', cls=P4DockerHost, ip='192.168.1.201',
                    dimage="containernet_example:lamp", mac="00:00:00:00:00:A1")
+d3.start()
 
 info('*** Adding switches\n')
 

--- a/P4_examples/load_balancer_hash/load_balancer_hash.p4
+++ b/P4_examples/load_balancer_hash/load_balancer_hash.p4
@@ -189,7 +189,7 @@ control c_ingress(inout headers_t hdr,
     }
 
     action _drop() {
-        mark_to_drop();
+        mark_to_drop(standard_metadata);
     }
 
     // Table counter used to count packets and bytes matched by each entry of

--- a/P4_examples/load_balancer_hash/load_balancer_hash_p4.py
+++ b/P4_examples/load_balancer_hash/load_balancer_hash_p4.py
@@ -23,6 +23,7 @@ info('*** Adding docker containers\n')
 # Fake HOST
 d1 = net.addDocker('d1', cls=P4DockerHost, ip='192.168.1.100',
                    dimage="containernet_example:ubuntup4", mac="00:00:00:00:00:01")
+d1.start()
 # HOST
 h1 = net.addHost('h1', ip='192.168.1.104', mac="00:00:00:00:00:04")
 h2 = net.addHost('h2', ip='192.168.1.105', mac="00:00:00:00:00:05")
@@ -36,8 +37,10 @@ h2 = net.addHost('h2', ip='192.168.1.105', mac="00:00:00:00:00:05")
 # LAMP servers
 d2 = net.addDocker('d2', cls=P4DockerHost, ip='192.168.1.200',
                    dimage="containernet_example:lamp", mac="00:00:00:00:00:A0")
+d2.start()
 d3 = net.addDocker('d3', cls=P4DockerHost, ip='192.168.1.201',
                    dimage="containernet_example:lamp", mac="00:00:00:00:00:A1")
+d3.start()
 
 info('*** Adding switches\n')
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Wait (and have a coffee) ...
 Start example topology with some empty Docker containers connected to the network.
 
 * `cd FOP4`
-* run: `sudo python examples/containernet_example.py`
+* run: `sudo python3 examples/containernet_example.py`
 * use: `containernet> d1 ifconfig` to see config of container `d1`
 * use: `containernet> d1 ping -c4 d2` to ping between containers
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ $ cd ..
 The script will add the tools folders to PATH through your bash profile file.
 To load them without rebooting, run `source ~/.profile`
 
+### XDP backend for P4C
+If you also intend to use [p4c-xdp](https://github.com/vmware/p4c-xdp) (an XDP backend for P4C) it can be installed using the included script.
+```bash
+$ cd util
+$ ./install-p4c-xdp.sh
+$ cd ..
+```
+
+The script will add necessary environment variables to your bash profile file.
+To load them without rebooting, run `source ~/.profile`
+
 ### FOP4
 
 * Requires **Ubuntu Linux 20.04 LTS**, **Python3** and **P4 tools**.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $ git clone https://github.com/ANTLab-polimi/FOP4.git
 $ cd FOP4/ansible
 $ sudo ansible-playbook -i "localhost," -c local install.yml
 $ cd ..
-$ sudo python setup.py install
+$ sudo python3 setup.py install
 ```
 Wait (and have a coffee) ...
 

--- a/README.md
+++ b/README.md
@@ -38,16 +38,37 @@ If you use FOP4 for your research and/or other publications, please cite (beside
 
 ---
 ## Installation
+For a smooth installation process, it is suggested to install FOP4 and P4 tools in the root of your home directory. The following instructions will guide you in the process: 
+```bash
+$ cd
+$ git clone https://github.com/ANTLab-polimi/FOP4.git
+$ cd FOP4
+```
 
-Automatic installation is provided through an Ansible playbook.
+### P4 tools (Dependencies)
+P4 tools are necessary to run the P4 examples included with FOP4 and to be able to use all of its features. It's highly reccomended to use the included script to automate the installation of a compatible version:
 
-* Requires: **Ubuntu Linux 18.04 LTS** and **Python3** and **P4 tools installed** (see P4_example folder)
-* Experimental: **Ubuntu Linux 20.04 LTS** and **Python3** and **P4 tools installed** (see P4_example folder)
+* Requires a clean instance of **Ubuntu Linux 20.04 LTS** with the following minimum specs:
+    * At least 2GB of RAM
+    * At least 12GB of **FREE** disk space 
+```bash
+$ cd util
+$ ./install-p4-dependencies.sh
+$ cd ..
+```
+**WARNING:** It may take over an hour for this installation to complete
+
+The script will add the tools folders to PATH through your bash profile file.
+To load them without rebooting, run `source ~/.profile`
+
+### FOP4
+
+* Requires **Ubuntu Linux 20.04 LTS**, **Python3** and **P4 tools**.
+* If P4 tools have been installed with the provided script, the machine is already configured to install FOP4 without additional requirements.
 
 ```bash
-$ sudo apt-get install ansible git aptitude
-$ git clone https://github.com/ANTLab-polimi/FOP4.git
-$ cd FOP4/ansible
+$ cd ansible
+$ sudo apt-get install -y ansible aptitude
 $ sudo ansible-playbook -i "localhost," -c local install.yml
 $ cd ..
 $ sudo python3 setup.py install

--- a/examples/miniedit.py
+++ b/examples/miniedit.py
@@ -2583,7 +2583,7 @@ class MiniEdit( Frame ):
 
     def clickNode( self, event ):
         "Node click handler."
-        if self.active is 'NetLink':
+        if self.active == 'NetLink':
             self.startLink( event )
         else:
             self.selectNode( event )
@@ -2591,14 +2591,14 @@ class MiniEdit( Frame ):
 
     def dragNode( self, event ):
         "Node drag handler."
-        if self.active is 'NetLink':
+        if self.active == 'NetLink':
             self.dragNetLink( event )
         else:
             self.dragNodeAround( event )
 
     def releaseNode( self, event ):
         "Node release handler."
-        if self.active is 'NetLink':
+        if self.active == 'NetLink':
             self.finishLink( event )
 
     # Specific node handlers
@@ -2915,7 +2915,7 @@ class MiniEdit( Frame ):
                 newP4SwitchOpts['pipeconf'] = p4switchBox.result['pipeconf']
             newP4SwitchOpts['switchIP'] = p4switchBox.result['switchIP']
             self.switchOpts[name] = newP4SwitchOpts
-            print 'New P4Switch details for ' + name + ' = ' + str(newP4SwitchOpts)
+            print('New P4Switch details for ' + name + ' = ' + str(newP4SwitchOpts))
 
     def switchDetails( self, _ignore=None ):
         if ( self.selection is None or
@@ -2927,7 +2927,7 @@ class MiniEdit( Frame ):
         tags = self.canvas.gettags( self.selection )
         if 'Switch' not in tags:
             return
-        print name
+        print(name)
         prefDefaults = self.switchOpts[name]
         switchBox = SwitchDialog(self, title='Switch Details', prefDefaults=prefDefaults)
         self.master.wait_window(switchBox.top)
@@ -3422,7 +3422,6 @@ class MiniEdit( Frame ):
             dpctl = int(self.appPrefs['dpctl'])
         net = Containernet( topo=None,
                        listenPort=dpctl,
-                       build=False,
                        ipBase=self.appPrefs['ipBase'] )
 
         self.buildNodes(net)

--- a/mininet/bmv2.py
+++ b/mininet/bmv2.py
@@ -249,7 +249,7 @@ class ONOSBmv2Switch(Switch):
         urllib.request.install_opener(urllib.request.build_opener(
             urllib.request.HTTPBasicAuthHandler(pm)))
         # Push config data to controller
-        req = urllib.request.Request(url, json.dumps(cfgData),
+        req = urllib.request.Request(url, json.dumps(cfgData).encode("utf-8"),
                               {'Content-Type': 'application/json'})
         try:
             f = urllib.request.urlopen(req)

--- a/mininet/bmv2.py
+++ b/mininet/bmv2.py
@@ -24,7 +24,7 @@ import random
 import re
 import socket
 import threading
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 from contextlib import closing
 
 import time
@@ -77,7 +77,7 @@ def watchDog(sw):
             else:
                 warn("\n*** WARN: BMv2 instance %s died!\n" % sw.name)
                 sw.printBmv2Log()
-                print ("-" * 80) + "\n"
+                print(("-" * 80) + "\n")
                 return
 
 
@@ -239,23 +239,23 @@ class ONOSBmv2Switch(Switch):
         # Build netcfg URL
         url = 'http://%s:8181/onos/v1/network/configuration/' % controllerIP
         # Instantiate password manager for HTTP auth
-        pm = urllib2.HTTPPasswordMgrWithDefaultRealm()
+        pm = urllib.request.HTTPPasswordMgrWithDefaultRealm()
         pm.add_password(None, url,
                         # os.environ['ONOS_WEB_USER'],
                         # os.environ['ONOS_WEB_PASS']
                         ONOS_WEB_USER,
                         ONOS_WEB_PASS)
 
-        urllib2.install_opener(urllib2.build_opener(
-            urllib2.HTTPBasicAuthHandler(pm)))
+        urllib.request.install_opener(urllib.request.build_opener(
+            urllib.request.HTTPBasicAuthHandler(pm)))
         # Push config data to controller
-        req = urllib2.Request(url, json.dumps(cfgData),
+        req = urllib.request.Request(url, json.dumps(cfgData),
                               {'Content-Type': 'application/json'})
         try:
-            f = urllib2.urlopen(req)
-            print(f.read())
+            f = urllib.request.urlopen(req)
+            print((f.read()))
             f.close()
-        except urllib2.URLError as e:
+        except urllib.error.URLError as e:
             warn("*** WARN: unable to push config to ONOS (%s)\n" % e.reason)
 
     def start(self, controllers):
@@ -310,7 +310,7 @@ class ONOSBmv2Switch(Switch):
     def bmv2Thrift(self, *args, **kwargs):
         "Run ovs-vsctl command (or queue for later execution)"
         cli_command = SIMPLE_SWITCH_CLI + " --thrift-port " + str(self.thriftPort) + " <<< "
-        switch_cmd = ' '.join(map(str, filter(lambda ar: ar is not None, args)))
+        switch_cmd = ' '.join(map(str, [ar for ar in args if ar is not None]))
         command = cli_command + '"' + switch_cmd + '"'
         self.cmd(command)
 
@@ -319,9 +319,9 @@ class ONOSBmv2Switch(Switch):
         # TODO: find a better way to add a port at runtime
         if self.pktdump:
             pcapFiles = ["./" + str(intf) + "_out.pcap", "./" + str(intf) + "_in.pcap"]
-            self.bmv2Thrift('port_add', intf, next(key for key, value in self.intfs.items() if value == intf), *pcapFiles)
+            self.bmv2Thrift('port_add', intf, next(key for key, value in list(self.intfs.items()) if value == intf), *pcapFiles)
         else:
-            self.bmv2Thrift('port_add', intf, next(key for key, value in self.intfs.items() if value == intf))
+            self.bmv2Thrift('port_add', intf, next(key for key, value in list(self.intfs.items()) if value == intf))
         self.cmd('ifconfig', intf, 'up')
         # TODO: check if need to send a new netcfg
         # if self.controllers is not None and len(controllers) > 0 :
@@ -335,7 +335,7 @@ class ONOSBmv2Switch(Switch):
         if self.thriftPort is None:
             self.thriftPort = pickUnusedPort()
         args = ['--device-id %s' % self.p4DeviceId]
-        for port, intf in self.intfs.items():
+        for port, intf in list(self.intfs.items()):
             if not intf.IP():
                 args.append('-i %d@%s' % (port, intf.name))
         args.append('--thrift-port %s' % self.thriftPort)
@@ -382,14 +382,14 @@ class ONOSBmv2Switch(Switch):
 
     def printBmv2Log(self):
         if os.path.isfile(self.logfile):
-            print("-" * 80)
-            print("%s log (from %s):" % (self.name, self.logfile))
+            print(("-" * 80))
+            print(("%s log (from %s):" % (self.name, self.logfile)))
             with open(self.logfile, 'r') as f:
                 lines = f.readlines()
                 if len(lines) > BMV2_LOG_LINES:
                     print("...")
                 for line in lines[-BMV2_LOG_LINES:]:
-                    print(line.rstrip())
+                    print((line.rstrip()))
 
     @staticmethod
     def controllerIp(controllers):

--- a/mininet/bmv2.py
+++ b/mininet/bmv2.py
@@ -253,7 +253,7 @@ class ONOSBmv2Switch(Switch):
                               {'Content-Type': 'application/json'})
         try:
             f = urllib.request.urlopen(req)
-            print((f.read()))
+            print(f.read())
             f.close()
         except urllib.error.URLError as e:
             warn("*** WARN: unable to push config to ONOS (%s)\n" % e.reason)
@@ -382,14 +382,14 @@ class ONOSBmv2Switch(Switch):
 
     def printBmv2Log(self):
         if os.path.isfile(self.logfile):
-            print(("-" * 80))
-            print(("%s log (from %s):" % (self.name, self.logfile)))
+            print("-" * 80)
+            print("%s log (from %s):" % (self.name, self.logfile))
             with open(self.logfile, 'r') as f:
                 lines = f.readlines()
                 if len(lines) > BMV2_LOG_LINES:
                     print("...")
                 for line in lines[-BMV2_LOG_LINES:]:
-                    print((line.rstrip()))
+                    print(line.rstrip())
 
     @staticmethod
     def controllerIp(controllers):

--- a/mininet/cli.py
+++ b/mininet/cli.py
@@ -147,7 +147,7 @@ class CLI( Cmd ):
     def do_help( self, line ):
         "Describe available CLI commands."
         Cmd.do_help( self, line )
-        if line is '':
+        if line == '':
             output( self.helpStr )
 
     def do_nodes( self, _line ):
@@ -447,7 +447,7 @@ class CLI( Cmd ):
                 # XXX BL: this doesn't quite do what we want.
                 if False and self.inputFile:
                     key = self.inputFile.read( 1 )
-                    if key is not '':
+                    if key != '':
                         node.write( key )
                     else:
                         self.inputFile = None

--- a/util/install-p4-dependencies.sh
+++ b/util/install-p4-dependencies.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+############
+# Tested on a clean Ubuntu 20.04 LTS installation
+#
+# Required specs:
+# - At least 2GB of RAM
+# - At least 12GB of FREE disk space
+############
+
+#Install everything in the home directory
+cd
+
+#Install basic packages
+sudo apt update
+sudo apt install -y git
+
+#Install dependencies with the script from https://github.com/jafingerhut/p4-guide/blob/master/bin/README-install-troubleshooting.md
+git clone https://github.com/jafingerhut/p4-guide
+./p4-guide/bin/install-p4dev-v4.sh |& tee dependencies_log.txt
+
+#Add paths to environment
+cat p4setup.bash >> .profile
+
+#Uninstall mininet pip package installed by the script, it will be substituded by the one of Containernet
+#Otherwise 'sudo python3 setup.py install' doesn't work correctly
+sudo pip3 uninstall -y mininet

--- a/util/install-p4-dependencies.sh
+++ b/util/install-p4-dependencies.sh
@@ -13,7 +13,6 @@ cd
 
 #Install basic packages
 sudo apt update
-sudo apt install -y git
 
 #Install dependencies with the script from https://github.com/jafingerhut/p4-guide/blob/master/bin/README-install-troubleshooting.md
 git clone https://github.com/jafingerhut/p4-guide

--- a/util/install-p4c-xdp.sh
+++ b/util/install-p4c-xdp.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+#Build libbpf
+sudo apt install -y libelf-dev clang
+cd ~/p4c/backends/ebpf/
+sudo ./build_libbpf
+
+#Clone
+cd ~/p4c/
+mkdir extensions
+cd extensions
+git clone https://github.com/vmware/p4c-xdp.git
+ln -s ~/p4c p4c-xdp/p4c
+
+#Make
+cd ~/p4c/
+mkdir -p build
+cd build/
+cmake ..
+make
+
+#Make soft links
+cd ~/p4c/extensions/p4c-xdp
+ln -s ~/p4c/build/p4c-xdp p4c-xdp
+ln -s ~/p4c/backends/ebpf/run-ebpf-test.py run-ebpf-test.py
+
+#Run tests
+cd ~/p4c/build/
+make check-xdp
+
+#Add needed env variables and load configuration
+echo "Adding env variables to .profile ..."
+echo 'export P4C="$HOME/p4c"' >> $HOME/.profile
+echo 'export PATH="$P4C/extensions/p4c-xdp:$PATH"' >> $HOME/.profile


### PR DESCRIPTION
* Install scripts for P4 tools and p4c-xdp have been added to the "util" folder
* P4 examples have been updated to work with the current versions of the tools and Python3
* Instructions in README files updated to reflect both additions

As a result, FOP4 can now be installed on Ubuntu 20.04 LTS